### PR TITLE
GitHub CI using Wordpress Plugin Check Action

### DIFF
--- a/.github/workflows/wp-phpcs.yml
+++ b/.github/workflows/wp-phpcs.yml
@@ -1,0 +1,80 @@
+name: WordPress Plugin Tests
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: wordpress_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          path: wieczos-virus-scanner
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, mysqli
+          ini-values: |
+            memory_limit=512M
+            upload_max_filesize=100M
+            post_max_size=100M
+          coverage: xdebug
+
+      - name: Install Composer Dependencies
+        run: |
+          cd wieczos-virus-scanner
+          if [ -f composer.lock ]; then composer install --prefer-dist --no-progress --no-suggest; else composer install; fi
+      - name: Install WP-CLI
+        run: |
+          curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+          chmod +x wp-cli.phar
+          sudo mv wp-cli.phar /usr/local/bin/wp
+      - name: Set up WordPress Test Environment
+        env:
+          DB_HOST: 127.0.0.1:3306
+          DB_NAME: wordpress_test
+          DB_USER: root
+          DB_PASS: root
+        run: |
+          wp core download --path=./wordpress --version=latest
+          wp config create --path=./wordpress --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --skip-check
+          wp core install --path=./wordpress --url=localhost --title="Test Site" --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+      - name: Install Plugin
+        run: |
+          mkdir -p ./wordpress/wp-content/plugins/wieczos-virus-scanner
+          # Kopiere alle Plugin-Dateien in das Plugins-Verzeichnis
+          cp -r ./wieczos-virus-scanner/* ./wordpress/wp-content/plugins/wieczos-virus-scanner/
+          wp plugin activate --path=./wordpress wieczos-virus-scanner # Aktiviert das Plugin aus dem Repository
+          if [ -f ./wordpress/wp-content/plugins/wieczos-virus-scanner/wieczos-virus-scanner.php ]; then
+            echo "Plugin-Datei gefunden."
+          else
+            echo "Plugin-Datei nicht gefunden."
+            exit 1
+          fi
+          # Aktiviere das Plugin
+          wp plugin activate wieczos-virus-scanner --path=./wordpress
+          
+      - name: Run PHP CodeSniffer
+        run: |
+          cd wieczos-virus-scanner
+          ./vendor/bin/phpcs --ignore=*/vendor/* --standard=WordPress --extensions=php .

--- a/.github/workflows/wp-phpcs.yml
+++ b/.github/workflows/wp-phpcs.yml
@@ -9,72 +9,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-
-    services:
-      mysql:
-        image: mysql:5.7
-        env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: wordpress_test
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping --silent"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          path: wieczos-virus-scanner
 
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.2'
-          extensions: mbstring, mysqli
-          ini-values: |
-            memory_limit=512M
-            upload_max_filesize=100M
-            post_max_size=100M
-          coverage: xdebug
-
-      - name: Install Composer Dependencies
-        run: |
-          cd wieczos-virus-scanner
-          if [ -f composer.lock ]; then composer install --prefer-dist --no-progress --no-suggest; else composer install; fi
-      - name: Install WP-CLI
-        run: |
-          curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-          chmod +x wp-cli.phar
-          sudo mv wp-cli.phar /usr/local/bin/wp
-      - name: Set up WordPress Test Environment
-        env:
-          DB_HOST: 127.0.0.1:3306
-          DB_NAME: wordpress_test
-          DB_USER: root
-          DB_PASS: root
-        run: |
-          wp core download --path=./wordpress --version=latest
-          wp config create --path=./wordpress --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --skip-check
-          wp core install --path=./wordpress --url=localhost --title="Test Site" --admin_user=admin --admin_password=admin --admin_email=admin@example.com
-      - name: Install Plugin
-        run: |
-          mkdir -p ./wordpress/wp-content/plugins/wieczos-virus-scanner
-          # Kopiere alle Plugin-Dateien in das Plugins-Verzeichnis
-          cp -r ./wieczos-virus-scanner/* ./wordpress/wp-content/plugins/wieczos-virus-scanner/
-          wp plugin activate --path=./wordpress wieczos-virus-scanner # Aktiviert das Plugin aus dem Repository
-          if [ -f ./wordpress/wp-content/plugins/wieczos-virus-scanner/wieczos-virus-scanner.php ]; then
-            echo "Plugin-Datei gefunden."
-          else
-            echo "Plugin-Datei nicht gefunden."
-            exit 1
-          fi
-          # Aktiviere das Plugin
-          wp plugin activate wieczos-virus-scanner --path=./wordpress
-          
-      - name: Run PHP CodeSniffer
-        run: |
-          cd wieczos-virus-scanner
-          ./vendor/bin/phpcs --ignore=*/vendor/* --standard=WordPress --extensions=php .
+      - name: Run plugin check
+        uses: wordpress/plugin-check-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please add your contribution here, following the format below.
 
 ## Unreleased
 
+* Enable CI action/workflow that uses [WordPress/plugin-check-action](https://github.com/WordPress/plugin-check-action).
 * Add new features
 
 ## 1.2.1


### PR DESCRIPTION
This PR implements the way slimmer way of phpcs using [wordpress/plugin-check-action](https://github.com/wordpress/plugin-check-action).

The first commit in this PR has a stub with the trial and error process of setting up php Code Sniffer.

Let me know if you want this in or not, I can happily rebase to the tiny remains of the action the PR will bring in anyways.

---

closes #3 

---

## Screenshot of the things the Pipeline will still moan about

<img width="1309" alt="image" src="https://github.com/user-attachments/assets/a19286ea-dfd2-412f-aac8-5085c3ad0bbc">
